### PR TITLE
Expand <cword> properly when provided as argument to asyncdo#run and friends

### DIFF
--- a/autoload/asyncdo.vim
+++ b/autoload/asyncdo.vim
@@ -30,7 +30,7 @@ endfunc
 func! s:escape(...) abort
   " if there are two args, s:escape is called from map(). use 2nd arg
   let str = a:0 == 2 ? a:2 : a:1
-  return s:slashescape(s:fnameexpand(str))
+  return expand(s:slashescape(s:fnameexpand(str)))
 endfunc
 
 func! s:build(scope, prefix, settitle) abort

--- a/autoload/asyncdo.vim
+++ b/autoload/asyncdo.vim
@@ -17,10 +17,20 @@ func! s:finalize(scope, prefix, settitle) abort
     endtry
 endfunc
 
+" expand filename-modifiers explicitly
+func! s:fnameexpand(str) abort
+  return substitute(a:str, '\v(\%|\#)(\:[phrte])*', {a->expand(a[0])}, 'g')
+endfunc
+
+" prepare backslashes for shell consumption via job logic in s:build
+func! s:slashescape(str) abort
+  return substitute(a:str, '\\', '\\\\\\', 'g')
+endfunc
+
 func! s:escape(...) abort
   " if there are two args, s:escape is called from map(). use 2nd arg
   let str = a:0 == 2 ? a:2 : a:1
-  return substitute(substitute(str, '\v(\%|\#)(\:[phrte])*', {a->expand(a[0])}, 'g'), '\\', '\\\\\\', 'g')
+  return s:slashescape(s:fnameexpand(str))
 endfunc
 
 func! s:build(scope, prefix, settitle) abort


### PR DESCRIPTION
Discussion is in #13.

A good part of why this was difficult for me to debug was due to an `expand()` not being immediately readable to me, because of all the nested `substitute()` calls. To mitigate this kind of issue in the future, the `substitute()` calls have been neatly extracted into their own functions.