### PR TITLE
Remove redundant -complete=file option

### DIFF
--- a/plugin/asyncdo.vim
+++ b/plugin/asyncdo.vim
@@ -12,9 +12,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 command! -bang -nargs=+ -complete=file AsyncDo   call asyncdo#run(<bang>0, <f-args>)
-command!       -nargs=0 -complete=file AsyncStop call asyncdo#stop()
+command!       -nargs=0                AsyncStop call asyncdo#stop()
 
 command! -bang -nargs=+ -complete=file LAsyncDo   call asyncdo#lrun(<bang>0, <f-args>)
-command!       -nargs=0 -complete=file LAsyncStop call asyncdo#lstop()
+command!       -nargs=0                LAsyncStop call asyncdo#lstop()
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Since Vim 8.2.3141, `-nargs=0` and the `-complete` option cannot be used
together anymore.

Related: https://github.com/vim/vim/pull/8544